### PR TITLE
Some fixes with Yuta help

### DIFF
--- a/source/stages/cutscenes/TwoPicos.hx
+++ b/source/stages/cutscenes/TwoPicos.hx
@@ -188,13 +188,13 @@ class TwoPicos
 			cigarette.flipX = true;
 
 			host.addBehindBF(cigarette);
-			//if (ClientPrefs.data.gore)
+			if (ClientPrefs.data.naughtyness)
 			host.addBehindBF(bloodPool);
 			host.addBehindBF(imposterPico);
 			host.addBehindBF(pico);
 
 			cigarette.setPosition(host.boyfriend.x - 143.5, host.boyfriend.y + 210);
-			//if (ClientPrefs.data.gore)
+			if (ClientPrefs.data.naughtyness)
 			bloodPool.setPosition(host.dad.x - 1487, host.dad.y - 173);
 
 			shooterPos = cameraPos(host.boyfriend, game.boyfriendCameraOffset);
@@ -203,12 +203,12 @@ class TwoPicos
 		else
 		{
 			host.addBehindDad(cigarette);
-			//if (ClientPrefs.data.gore)
+			if (ClientPrefs.data.naughtyness)
 			host.addBehindDad(bloodPool);
 			host.addBehindDad(pico);
 			host.addBehindDad(imposterPico);
-			//if (ClientPrefs.data.gore)
-			bloodPool.setPosition(host.boyfriend.x - 788.5, host.boyfriend.y - 173);
+			if (ClientPrefs.data.naughtyness)
+			bloodPool?.setPosition(host.boyfriend.x - 788.5, host.boyfriend.y - 173);
 			cigarette.setPosition(host.boyfriend.x - 478.5, host.boyfriend.y + 205);
 
 			cigarettePos = cameraPos(host.boyfriend, game.boyfriendCameraOffset);
@@ -216,7 +216,7 @@ class TwoPicos
 		}
 		var midPoint:Array<Float> = [(shooterPos[0] + cigarettePos[0]) / 2, (shooterPos[1] + cigarettePos[1]) / 2];
 
-		// Allw picos to set their cutscene timers
+		// Allow picos to set their cutscene timers
 		imposterPico.doAnim("Opponent", !playerShoots, explode, cutsceneHandler);
 		pico.doAnim("Player", playerShoots, explode, cutsceneHandler);
 
@@ -228,7 +228,7 @@ class TwoPicos
 			{
 				pico.shader = shader;
 				imposterPico.shader = shader;
-				//if (ClientPrefs.data.gore)
+				if (ClientPrefs.data.naughtyness)
 				bloodPool.shader = shader;
 			});
 		}
@@ -256,7 +256,7 @@ class TwoPicos
 
 		cutsceneHandler.timer(11.2, () ->
 		{
-			if (explode == true/* && ClientPrefs.data.gore*/)
+			if (explode == true && ClientPrefs.data.naughtyness)
 			{
 				bloodPool.visible = true;
 				bloodPool.anim.play("bloodPool", true);

--- a/source/stages/objects/PicoDopplegangerSprite.hx
+++ b/source/stages/objects/PicoDopplegangerSprite.hx
@@ -10,7 +10,9 @@ class PicoDopplegangerSprite extends FunkinSprite
 
   public function new(x:Float, y:Float)
   {
-    super(x, y, 'philly/erect/cutscenes/pico_doppleganger');
+    super(x, y);
+    loadTextureAtlas('philly/erect/cutscenes/pico_doppleganger', "week3");
+    // above code recommended by Z11 to fix Pico erect cutscene from not loading
   }
 
   var cutsceneSounds:FunkinSound = null;


### PR DESCRIPTION
In TwoPicos.hx, fixed the "Naughtyness" toggle crashing the game when loading any of the Pico stage Pico mix songs.

In PicoDoppleGangerSprite.hx, fixed cutscene not working thanks to Z11.